### PR TITLE
fix the SerializeToStream System.Text.Json benchmark by resetting the writer, not stream

### DIFF
--- a/Benchmarks/Serializers/SerializeToStream.cs
+++ b/Benchmarks/Serializers/SerializeToStream.cs
@@ -48,7 +48,7 @@ namespace Benchmarks.Serializers
         [Benchmark]
         public void RunSystemTextJson()
         {
-            _memoryStream.Position = 0;
+            _utf8JsonWriter.Reset();
             JsonSerializer.Serialize(_utf8JsonWriter, _instance);
         }
 


### PR DESCRIPTION
> In this benchmark, I wasn’t able to run System.Text.Json. When running with BenchmarkDotNet it throws an exception, so if you’ve got an idea why this happens or a workaround I’ll be happy to hear. 

```log
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.Text.Json.JsonException: The object or value could not be serialized. Path: $.
 ---> System.InvalidOperationException: Cannot write the start of an object/array after a single JSON value or outside of an existing closed object/array. Current token type is 'EndObject'.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource, Int32 currentDepth, Byte token, JsonTokenType tokenType)
   at System.Text.Json.Utf8JsonWriter.ValidateStart()
   at System.Text.Json.Utf8JsonWriter.WriteStartSlow(Byte token)
   at System.Text.Json.Utf8JsonWriter.WriteStart(Byte token)
   at System.Text.Json.WriteStackFrame.WriteObjectOrArrayStart(ClassType classType, Utf8JsonWriter writer, Boolean writeNull)
   at System.Text.Json.JsonSerializer.WriteObject(JsonSerializerOptions options, Utf8JsonWriter writer, WriteStack& state)
   at System.Text.Json.JsonSerializer.Write(Utf8JsonWriter writer, Int32 originalWriterDepth, Int32 flushThreshold, JsonSerializerOptions options, WriteStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(WriteStack& writeStack, Exception ex)
   at System.Text.Json.JsonSerializer.Write(Utf8JsonWriter writer, Int32 originalWriterDepth, Int32 flushThreshold, JsonSerializerOptions options, WriteStack& state)
   at System.Text.Json.JsonSerializer.WriteCore(Utf8JsonWriter writer, PooledByteBufferWriter output, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteValueCore(Utf8JsonWriter writer, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Serialize[TValue](Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
   at Benchmarks.Serializers.SerializeToStream`1.RunSystemTextJson() in C:\Projects\PracticalDebugging\Benchmarks\Serializers\SerializeToStream.cs:line 53
   at BenchmarkDotNet.Autogenerated.Runnable_0.WorkloadActionUnroll(Int64 invokeCount) in C:\Projects\PracticalDebugging\Benchmarks\bin\Release\netcoreapp3.0\c37c3560-a0b0-4413-94e7-771c3424c356\c37c3560-a0b0-4413-94e7-771c3424c356.notcs:line 725
   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
   at BenchmarkDotNet.Autogenerated.Runnable_0.Run(IHost host, String benchmarkName) in C:\Projects\PracticalDebugging\Benchmarks\bin\Release\netcoreapp3.0\c37c3560-a0b0-4413-94e7-771c3424c356\c37c3560-a0b0-4413-94e7-771c3424c356.notcs:line 163
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in C:\Projects\PracticalDebugging\Benchmarks\bin\Release\netcoreapp3.0\c37c3560-a0b0-4413-94e7-771c3424c356\c37c3560-a0b0-4413-94e7-771c3424c356.notcs:line 48
````

When using a writer to serialize to stream, you should be resetting the writer, not the stream position