### PR TITLE
Reset the memory stream position back to 0 between each benchmark run

### DIFF
--- a/Benchmarks/Serializers/SerializeToStream.cs
+++ b/Benchmarks/Serializers/SerializeToStream.cs
@@ -48,6 +48,7 @@ namespace Benchmarks.Serializers
         [Benchmark]
         public void RunSystemTextJson()
         {
+            _memoryStream.Position = 0;
             _utf8JsonWriter.Reset();
             JsonSerializer.Serialize(_utf8JsonWriter, _instance);
         }


### PR DESCRIPTION
Without this, the memory stream grows to be much larger than necessary, increasing the allocations for the larger benchmarks.

cc @adamsitnik, @michaelscodingspot