### PR TITLE
A better way to reference System.Net.Http.Formatting

### DIFF
--- a/BenchmarksServerDotNetCore3/BenchmarksServerDotNetCore3.csproj
+++ b/BenchmarksServerDotNetCore3/BenchmarksServerDotNetCore3.csproj
@@ -9,16 +9,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Utf8Json.AspNetCoreMvcFormatter" Version="1.3.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Benchmarks\Benchmarks.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Net.Http.Formatting">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnet.webapi.client\5.2.6\lib\netstandard2.0\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet.org recommends to use Microsoft.AspNet.WebApi.Client instead System.Net.Http.Formatting (which contains the same dll):
https://www.nuget.org/packages/system.net.http.formatting